### PR TITLE
Adding references about memory one strategies

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -7,3 +7,23 @@
 	doi = "10.1126/science.7466396",
 	year = 1981
 }
+@article{press2012iterated,
+  title={Iterated Prisoner’s Dilemma contains strategies that dominate any evolutionary opponent},
+  author={Press, William H and Dyson, Freeman J},
+  journal={Proceedings of the National Academy of Sciences},
+  volume={109},
+  number={26},
+  pages={10409--10413},
+  year={2012},
+  publisher={National Acad Sciences}
+}
+@article{stewart2012extortion,
+  title={Extortion and cooperation in the prisoner’s dilemma},
+  author={Stewart, Alexander J and Plotkin, Joshua B},
+  journal={Proceedings of the National Academy of Sciences},
+  volume={109},
+  number={26},
+  pages={10134--10135},
+  year={2012},
+  publisher={National Acad Sciences}
+}


### PR DESCRIPTION
After discussion on https://github.com/Axelrod-Python/Axelrod/issues/170 I've added these two references about memory one strategies:
- Stewart, Alexander J and Plotkin, Joshua B: Pnas
- Press, William H and Dyson, Freeman J: Pnas
